### PR TITLE
Trigger tests depending on changed files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,12 @@ on:
   push:
   pull_request:
     branches: [ main ]
-
+    paths:
+      - "build/*"
+      - "src/*"
+      - "test/*"
+      - "scripts/*"
+      
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -70,313 +75,23 @@ jobs:
         path: |
           dist/coco_experiment*.tar.gz
   
-  python-wheels-build:
-    needs: source-build
-    # This strategy is taken straight from the numpy wheels.yaml CI job
-    # 
-    # Since we depend on numpy, there's no reason to try and build a binary cocoex wheel
-    # on platform that don't have a compiled numpy available.
-    strategy:
-      # Ensure that a wheel builder finishes even if another fails
-      fail-fast: false
-      matrix:
-        buildplat:
-          - [ubuntu-20.04, manylinux_x86_64]
-          - [ubuntu-20.04, musllinux_x86_64]
-          - [macos-14, macosx_x86_64]
-          - [windows-2019, win_amd64]
-          - [windows-2019, win32]
-        python: ["cp39", "cp310", "cp311", "cp312", "pp39"]
-        exclude:
-          # Don't build PyPy 32-bit windows
-          - buildplat: [windows-2019, win32]
-            python: "pp39"
-          - buildplat: [ ubuntu-20.04, musllinux_x86_64 ]
-            python: "pp39"
-    runs-on: ${{ matrix.buildplat[0] }}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - name: Setup MSVC (32-bit)
-      if: ${{ matrix.buildplat[1] == 'win32' }}
-      uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
-      with:
-        architecture: 'x86'
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-    - name: Download Python source package
-      uses: actions/download-artifact@v3
-      with:
-        name: dist-python-sdist
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.16.2
-    - name: Build cocoex wheel
-      shell: bash
-      run: python -m cibuildwheel --output-dir dist/ coco_experiment-*.tar.gz
-      env:
-        CIBW_PRERELEASE_PYTHONS: True
-        CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-    - name: Archive Python wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist-python-wheels
-        path: dist/coco_experiment*.whl
-  
-  python-wheels-test:
-    needs: python-wheels-build
-    strategy:
-      matrix:
-        buildplat:
-          - [ubuntu-20.04, manylinux_x86_64]
-          - [ubuntu-20.04, musllinux_x86_64]
-          - [macos-14, macosx_x86_64]
-          - [windows-2019, win_amd64]
-          - [windows-2019, win32]
-        python: ["3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          # Don't build PyPy 32-bit windows
-          - buildplat: [windows-2019, win32]
-            python: "3.9"
-          - buildplat: [ ubuntu-20.04, musllinux_x86_64 ]
-            python: "3.9"
-    runs-on: ${{ matrix.buildplat[0] }}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist-python-sdist
-        path: dist
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist-python-wheels
-        path: wheels
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{matrix.python}}
-    - name: Setup Python
-      run: python -m pip install --upgrade pip wheel
-    - name: Install cocoex 
-      run: python -m pip install --find-links wheels/ coco-experiment
-    - name: Run cocoex test
-      shell: bash
-      run: |
-        tar xf dist/coco_experiment-*.tar.gz --strip-components=1
-        python -m pip install pytest pytest-cov
-        pytest --cov=cocoex test/
-  
-  python-wheels-example:
-    needs: [python-wheels-build, python-wheels-build]
-    strategy:
-      matrix:
-        buildplat:
-          - [ubuntu-20.04, manylinux_x86_64]
-          - [ubuntu-20.04, musllinux_x86_64]
-          - [macos-14, macosx_x86_64]
-          - [windows-2019, win_amd64]
-          - [windows-2019, win32]
-        python: ["3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          # Don't build PyPy 32-bit windows
-          - buildplat: [windows-2019, win32]
-            python: "3.9"
-          - buildplat: [ ubuntu-20.04, musllinux_x86_64 ]
-            python: "3.9"
-    runs-on: ${{ matrix.buildplat[0] }}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist-python-wheels
-        path: wheels
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{matrix.python}}
-    - name: Setup Python
-      run: python -m pip install --upgrade pip wheel
-    - name: Install cocoex and cocopp
-      run: python -m pip install --find-links wheels/ coco-experiment cocopp
-    - name: Install scipy for example experiment
-      run: python -m pip install scipy
-    - name: Run example experiment
-      run: python build/python/example/example_experiment2.py
 
-  python-lint:
+  python_test:
     needs: source-build
-    runs-on: "ubuntu-latest"
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist-python-sdist
-        path: dist
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-    - name: Setup Python
-      run: python -m pip install --upgrade pip wheel
-    - name: Lint with Ruff
-      shell: bash
-      continue-on-error: true
-      run: |
-        pip install ruff
-        tar xf dist/coco_experiment*.tar.gz --strip-components=1
-        ruff check --output-format=github .
+    uses: ./.github/workflows/test_python.yml
 
   c-test:
     needs: source-build
-    strategy:
-      matrix:
-        # FIXME: Currently fails on windows because of path issues.
-        # 
-        # Debug and add `windows-latest` back to list at some point.
-        os: [ubuntu-latest, macos-14]
-    runs-on: ${{matrix.os}}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - name: Download C source package
-      uses: actions/download-artifact@v3
-      with:
-        name: dist-c
-    - name: Unpack
-      run: unzip cocoex-c-*.zip
-    - name: Build 
-      working-directory: ${{github.workspace}}/cocoex-c/
-      run: cmake -B build && cmake --build build
-    - name: Test
-      working-directory: ${{github.workspace}}/cocoex-c/
-      run: ctest --test-dir build 
-    - name: Store reports
-      if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: c-test-${{matrix.os}}
-        path: |
-            **/build/
-  
+    uses: ./.github/workflows/test_c.yml
+ 
   java-example:
     needs: source-build
-    strategy:
-      matrix:
-        # FIXME: Currently fails on windows because of path issues.
-        # 
-        # Debug and add `windows-latest` back to list at some point.
-        os: [ubuntu-latest, macos-14]
-        java: [11, 17, 21] 
-    runs-on: ${{matrix.os}}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - name: Download Java source package
-      uses: actions/download-artifact@v3
-      with:
-        name: dist-java
-    - name: Setup java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-    - name: Unpack
-      run: unzip cocoex-java-*.zip
-    - name: Build 
-      working-directory: ${{github.workspace}}/cocoex-java/
-      run: cmake -B build && cmake --build build
-    - name: Experiment
-      working-directory: ${{github.workspace}}/cocoex-java/
-      run: java -classpath build/coco.jar -Djava.library.path=build/ ExampleExperiment 
-    - name: Archive Java example experiment results
-      uses: actions/upload-artifact@v3
-      with:
-        name: java-example-${{matrix.os}}
-        path: cocoex-java/exdata/*
+    uses: ./.github/workflows/test_java.yml
 
   octave-example:
     needs: source-build
-    # FIXME: Should also test on windows and macos
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - name: Install Octave
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y octave liboctave-dev
-    - name: Download Octave source package
-      uses: actions/download-artifact@v3
-      with:
-        name: dist-octave
-    - name: Unpack
-      run: unzip cocoex-octave-*.zip
-    - name: Build 
-      working-directory: ${{github.workspace}}/cocoex-octave/
-      run: mkoctfile --verbose --mex cocoCall.c  
-    - name: Experiment
-      working-directory: ${{github.workspace}}/cocoex-octave/
-      run: octave --no-gui exampleexperiment.m                
-    - name: Archive Octave example experiment results
-      uses: actions/upload-artifact@v3
-      with:
-        name: octave-example
-        path: cocoex-octave/exdata/*
+    uses: ./.github/workflows/test_octave.yml
   
   rust-test:
-    if: false # Disabled since we don't have any tests yes
     needs: source-build
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{matrix.os}}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - name: Download Rust source package
-      uses: actions/download-artifact@v3
-      with:
-        name: dist-rust
-    - name: Unpack
-      run: unzip cocoex-rust-*.zip
-    - name: Build 
-      working-directory: ${{github.workspace}}/cocoex-rust/
-      run: cargo build -r
-    - name: Test 
-      working-directory: ${{github.workspace}}/cocoex-rust/
-      run: cargo test -r
-
-  rust-example:
-    needs: source-build
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{matrix.os}}
-    defaults:
-      run:
-        working-directory: ${{github.workspace}}
-    steps:
-    - name: Download Rust source package
-      uses: actions/download-artifact@v3
-      with:
-        name: dist-rust
-    - name: Unpack
-      run: unzip cocoex-rust-*.zip
-    - name: Build 
-      working-directory: ${{github.workspace}}/cocoex-rust/
-      run: cargo build -r 
-    - name: Example Experiment
-      working-directory: ${{github.workspace}}/cocoex-rust/
-      run: cargo run --example example-experiment
-    - name: Archive Rust example experiment results
-      uses: actions/upload-artifact@v3
-      with:
-        name: rust-example-${{matrix.os}}
-        path: cocoex-rust/exdata/*
+    uses: ./.github/workflows/test_rust.yml

--- a/.github/workflows/test_c.yml
+++ b/.github/workflows/test_c.yml
@@ -1,0 +1,47 @@
+name: test-c
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "build/c/*"
+      - "src/*"
+      
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  c-test:
+    strategy:
+      matrix:
+        # FIXME: Currently fails on windows because of path issues.
+        # 
+        # Debug and add `windows-latest` back to list at some point.
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - name: Download C source package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-c
+    - name: Unpack
+      run: unzip cocoex-c-*.zip
+    - name: Build 
+      working-directory: ${{github.workspace}}/cocoex-c/
+      run: cmake -B build && cmake --build build
+    - name: Test
+      working-directory: ${{github.workspace}}/cocoex-c/
+      run: ctest --test-dir build 
+    - name: Store reports
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: c-test-${{matrix.os}}
+        path: |
+            **/build/
+

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -1,0 +1,51 @@
+name: test-java
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "build/java/*"
+      - "src/*"
+      
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  java-example:
+    strategy:
+      matrix:
+        # FIXME: Currently fails on windows because of path issues.
+        # 
+        # Debug and add `windows-latest` back to list at some point.
+        os: [ubuntu-latest, macos-14]
+        java: [11, 17, 21] 
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - name: Download Java source package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-java
+    - name: Setup java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+    - name: Unpack
+      run: unzip cocoex-java-*.zip
+    - name: Build 
+      working-directory: ${{github.workspace}}/cocoex-java/
+      run: cmake -B build && cmake --build build
+    - name: Experiment
+      working-directory: ${{github.workspace}}/cocoex-java/
+      run: java -classpath build/coco.jar -Djava.library.path=build/ ExampleExperiment 
+    - name: Archive Java example experiment results
+      uses: actions/upload-artifact@v3
+      with:
+        name: java-example-${{matrix.os}}
+        path: cocoex-java/exdata/*

--- a/.github/workflows/test_octave.yml
+++ b/.github/workflows/test_octave.yml
@@ -1,0 +1,44 @@
+name: test-octave
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "build/octave/*"
+      - "src/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  octave-example:
+    # FIXME: Should also test on windows and macos
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - name: Install Octave
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y octave liboctave-dev
+    - name: Download Octave source package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-octave
+    - name: Unpack
+      run: unzip cocoex-octave-*.zip
+    - name: Build 
+      working-directory: ${{github.workspace}}/cocoex-octave/
+      run: mkoctfile --verbose --mex cocoCall.c  
+    - name: Experiment
+      working-directory: ${{github.workspace}}/cocoex-octave/
+      run: octave --no-gui exampleexperiment.m                
+    - name: Archive Octave example experiment results
+      uses: actions/upload-artifact@v3
+      with:
+        name: octave-example
+        path: cocoex-octave/exdata/*

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -1,0 +1,173 @@
+name: test-python
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "build/python/*"
+      - "src/*"
+      - "test/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  
+  python-wheels-build:
+    # This strategy is taken straight from the numpy wheels.yaml CI job
+    # 
+    # Since we depend on numpy, there's no reason to try and build a binary cocoex wheel
+    # on platform that don't have a compiled numpy available.
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        buildplat:
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [ubuntu-20.04, musllinux_x86_64]
+          - [macos-14, macosx_x86_64]
+          - [windows-2019, win_amd64]
+          - [windows-2019, win32]
+        python: ["cp39", "cp310", "cp311", "cp312", "pp39"]
+        exclude:
+          # Don't build PyPy 32-bit windows
+          - buildplat: [windows-2019, win32]
+            python: "pp39"
+          - buildplat: [ ubuntu-20.04, musllinux_x86_64 ]
+            python: "pp39"
+    runs-on: ${{ matrix.buildplat[0] }}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - name: Setup MSVC (32-bit)
+      if: ${{ matrix.buildplat[1] == 'win32' }}
+      uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
+      with:
+        architecture: 'x86'
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Download Python source package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-python-sdist
+    - name: Install cibuildwheel
+      run: python -m pip install cibuildwheel==2.16.2
+    - name: Build cocoex wheel
+      shell: bash
+      run: python -m cibuildwheel --output-dir dist/ coco_experiment-*.tar.gz
+      env:
+        CIBW_PRERELEASE_PYTHONS: True
+        CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    - name: Archive Python wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-python-wheels
+        path: dist/coco_experiment*.whl
+  
+  python-wheels-test:
+    needs: python-wheels-build
+    strategy:
+      matrix:
+        buildplat:
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [ubuntu-20.04, musllinux_x86_64]
+          - [macos-14, macosx_x86_64]
+          - [windows-2019, win_amd64]
+          - [windows-2019, win32]
+        python: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          # Don't build PyPy 32-bit windows
+          - buildplat: [windows-2019, win32]
+            python: "3.9"
+          - buildplat: [ ubuntu-20.04, musllinux_x86_64 ]
+            python: "3.9"
+    runs-on: ${{ matrix.buildplat[0] }}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist-python-sdist
+        path: dist
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist-python-wheels
+        path: wheels
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{matrix.python}}
+    - name: Setup Python
+      run: python -m pip install --upgrade pip wheel
+    - name: Install cocoex 
+      run: python -m pip install --find-links wheels/ coco-experiment
+    - name: Run cocoex test
+      shell: bash
+      run: |
+        tar xf dist/coco_experiment-*.tar.gz --strip-components=1
+        python -m pip install pytest pytest-cov
+        pytest --cov=cocoex test/
+  
+  python-wheels-example:
+    needs: [python-wheels-build, python-wheels-build]
+    strategy:
+      matrix:
+        buildplat:
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [ubuntu-20.04, musllinux_x86_64]
+          - [macos-14, macosx_x86_64]
+          - [windows-2019, win_amd64]
+          - [windows-2019, win32]
+        python: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          # Don't build PyPy 32-bit windows
+          - buildplat: [windows-2019, win32]
+            python: "3.9"
+          - buildplat: [ ubuntu-20.04, musllinux_x86_64 ]
+            python: "3.9"
+    runs-on: ${{ matrix.buildplat[0] }}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist-python-wheels
+        path: wheels
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{matrix.python}}
+    - name: Setup Python
+      run: python -m pip install --upgrade pip wheel
+    - name: Install cocoex and cocopp
+      run: python -m pip install --find-links wheels/ coco-experiment cocopp
+    - name: Install scipy for example experiment
+      run: python -m pip install scipy
+    - name: Run example experiment
+      run: python build/python/example/example_experiment2.py
+
+  python-lint:
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist-python-sdist
+        path: dist
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Setup Python
+      run: python -m pip install --upgrade pip wheel
+    - name: Lint with Ruff
+      shell: bash
+      continue-on-error: true
+      run: |
+        pip install ruff
+        tar xf dist/coco_experiment*.tar.gz --strip-components=1
+        ruff check --output-format=github .

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -1,0 +1,65 @@
+name: test-rust
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "build/rust/*"
+      - "src/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  
+  rust-test:
+    if: false # Disabled since we don't have any tests yes
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - name: Download Rust source package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-rust
+    - name: Unpack
+      run: unzip cocoex-rust-*.zip
+    - name: Build 
+      working-directory: ${{github.workspace}}/cocoex-rust/
+      run: cargo build -r
+    - name: Test 
+      working-directory: ${{github.workspace}}/cocoex-rust/
+      run: cargo test -r
+
+  rust-example:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}
+    steps:
+    - name: Download Rust source package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-rust
+    - name: Unpack
+      run: unzip cocoex-rust-*.zip
+    - name: Build 
+      working-directory: ${{github.workspace}}/cocoex-rust/
+      run: cargo build -r 
+    - name: Example Experiment
+      working-directory: ${{github.workspace}}/cocoex-rust/
+      run: cargo run --example example-experiment
+    - name: Archive Rust example experiment results
+      uses: actions/upload-artifact@v3
+      with:
+        name: rust-example-${{matrix.os}}
+        path: cocoex-rust/exdata/*


### PR DESCRIPTION
Tests are now only triggering if corresponding files have changed - specifically important if changes only happen to a specific language interface. To hopefully make maintenance easier, the workflow files are also split up now.

In order to ensure that all artefacts still exists for all tags, those are built independently of where changes are made.

:warning: Please check that I found all the required paths that would need to trigger a change.